### PR TITLE
Emulate opposite ENDISM, and test all combinations with WORD_BYTES

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,9 @@ matrix:
   include:
     - os: linux
     - os: osx
-    - env: WORD_BYTES=4
-    - env: WORD_BYTES=8
     - compiler: gcc
       env:
-        - MATRIX_EVAL="CC=gcc-8"
+        - MATRIX_EVAL="CC=gcc-8 GLOBAL_CONFIGURE_OPTS=--enable-silent-rules"
         # - CFLAGS="-g3 -fsanitize=address -fsanitize=undefined"
         # - LDFLAGS="-fsanitize=address -fsanitize=undefined"
         # - PY_LOG_ENV="LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/7/libasan.so PYTHONMALLOC=malloc"
@@ -45,7 +43,6 @@ before_install:
 
 # Run make install so that Python's ctypes.util.find_library works on Python < 3.6
 script:
-  - ./bootstrap && ./configure --enable-silent-rules
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install help2man ; fi
-  - make && sudo make install
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make check ; else make distcheck ; fi
+  - ./bootstrap
+  - for flavour in "CFLAGS=-DWORD_BYTES=4 -DENDISM=0" "CFLAGS=-DWORD_BYTES=4 -DENDISM=1" "CFLAGS=-DWORD_BYTES=8 -DENDISM=0" "CFLAGS=-DWORD_BYTES=8 -DENDISM=1"; do ./configure $GLOBAL_CONFIGURE_OPTS "$flavour" && make && sudo make install && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make check ; else make distcheck ; fi; done

--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -1,4 +1,4 @@
-# bootstrap.conf (smite) version 2019-03-31
+# bootstrap.conf (smite) version 2019-04-09
 
 # (c) SMite authors 1995-2019
 #
@@ -43,6 +43,7 @@ gnulib_tool_options='
 gnulib_modules='
         binary-io
         bootstrap
+        byteswap
         fcntl
         fdatasync
         getopt-gnu

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -144,3 +144,4 @@
 /wcrtomb.m4
 /strings_h.m4
 /getpagesize.m4
+/byteswap.m4

--- a/python/smite/__init__.py
+++ b/python/smite/__init__.py
@@ -220,7 +220,7 @@ class State:
         if not is_aligned(address) or ptr == None:
             return -1
 
-        fd = os.open(file, os.O_CREAT | os.O_RDWR | O_BINARY)
+        fd = os.open(file, os.O_CREAT | os.O_RDWR | O_BINARY, mode=0o666)
         if fd < 0:
             raise Error("cannot open file {}".format(file))
         try:

--- a/python/smite/binding.py
+++ b/python/smite/binding.py
@@ -55,7 +55,7 @@ def errcheck(code_to_message):
 
 # Constants (all of type unsigned)
 vars().update([(c, c_uint.in_dll(libsmite, "smite_{}".format(c)).value)
-               for c in ["word_bytes", "size_word",
+               for c in ["word_bytes", "endism", "size_word",
                          "byte_bit", "byte_mask", "word_bit",
                          "instruction_bit", "instruction_mask"]])
 sign_bit = 1 << (word_bit - 1)

--- a/src/main.c
+++ b/src/main.c
@@ -150,11 +150,12 @@ int main(int argc, char *argv[])
             usage();
             break;
         case 3:
-            printf(PACKAGE_NAME " " VERSION "\n"
+            printf(PACKAGE_NAME " " VERSION " (%d-byte word, %s-endian)\n"
                    "(c) SMite authors 1994-2019\n"
                    PACKAGE_NAME " comes with ABSOLUTELY NO WARRANTY.\n"
                    "You may redistribute copies of " PACKAGE_NAME "\n"
-                   "under the terms of the MIT/X11 License.\n");
+                   "under the terms of the MIT/X11 License.\n",
+                   WORD_BYTES, ENDISM ? "big" : "little");
             exit(EXIT_SUCCESS);
         default:
             break;

--- a/src/object.c
+++ b/src/object.c
@@ -56,6 +56,8 @@ ptrdiff_t smite_load_object(smite_state *S, smite_UWORD addr, int fd)
     smite_UWORD len = 0;
     if ((res = read(fd, &len, sizeof(len))) == -1)
         return -1;
+    if (ENDISM != DEFAULT_ENDISM)
+        len = reverse_endianness(len);
     if (res != sizeof(len))
         return -2;
     uint8_t *ptr = smite_native_address_of_range(S, addr, len);
@@ -82,9 +84,13 @@ int smite_save_object(smite_state *S, smite_UWORD addr, smite_UWORD len, int fd)
     buf[sizeof(PACKAGE_UPPER)] = ENDISM;
     buf[sizeof(PACKAGE_UPPER) + 1] = WORD_BYTES;
 
+    smite_UWORD len_save = len;
+    if (ENDISM != DEFAULT_ENDISM)
+        len_save = reverse_endianness(len_save);
+
     if (write(fd, hashbang, sizeof(hashbang) - 1) != sizeof(hashbang) - 1 ||
         write(fd, &buf[0], HEADER_LENGTH) != HEADER_LENGTH ||
-        write(fd, &len, sizeof(len)) != sizeof(len) ||
+        write(fd, &len_save, sizeof(len_save)) != sizeof(len_save) ||
         write(fd, ptr, len) != (ssize_t)len)
         return -1;
 

--- a/src/object.c
+++ b/src/object.c
@@ -48,7 +48,7 @@ ptrdiff_t smite_load_object(smite_state *S, smite_UWORD addr, int fd)
         memcmp(header, PACKAGE_UPPER, sizeof(PACKAGE_UPPER)) ||
         (endism = header[sizeof(PACKAGE_UPPER)]) > 1)
         return -2;
-    if (endism != S->ENDISM ||
+    if (endism != ENDISM ||
         (_WORD_BYTES = header[sizeof(PACKAGE_UPPER) + 1]) != WORD_BYTES)
         return -3;
 
@@ -79,7 +79,7 @@ int smite_save_object(smite_state *S, smite_UWORD addr, smite_UWORD len, int fd)
 
     char hashbang[] = "#!/usr/bin/env smite\n";
     smite_BYTE buf[HEADER_LENGTH] = PACKAGE_UPPER;
-    buf[sizeof(PACKAGE_UPPER)] = S->ENDISM;
+    buf[sizeof(PACKAGE_UPPER)] = ENDISM;
     buf[sizeof(PACKAGE_UPPER) + 1] = WORD_BYTES;
 
     if (write(fd, hashbang, sizeof(hashbang) - 1) != sizeof(hashbang) - 1 ||

--- a/src/object.c
+++ b/src/object.c
@@ -79,7 +79,6 @@ int smite_save_object(smite_state *S, smite_UWORD addr, smite_UWORD len, int fd)
     if (!smite_is_aligned(addr, smite_SIZE_WORD) || ptr == NULL)
         return -2;
 
-    char hashbang[] = "#!/usr/bin/env smite\n";
     smite_BYTE buf[HEADER_LENGTH] = PACKAGE_UPPER;
     buf[sizeof(PACKAGE_UPPER)] = ENDISM;
     buf[sizeof(PACKAGE_UPPER) + 1] = WORD_BYTES;
@@ -88,8 +87,7 @@ int smite_save_object(smite_state *S, smite_UWORD addr, smite_UWORD len, int fd)
     if (ENDISM != DEFAULT_ENDISM)
         len_save = reverse_endianness(len_save);
 
-    if (write(fd, hashbang, sizeof(hashbang) - 1) != sizeof(hashbang) - 1 ||
-        write(fd, &buf[0], HEADER_LENGTH) != HEADER_LENGTH ||
+    if (write(fd, &buf[0], HEADER_LENGTH) != HEADER_LENGTH ||
         write(fd, &len_save, sizeof(len_save)) != sizeof(len_save) ||
         write(fd, ptr, len) != (ssize_t)len)
         return -1;

--- a/src/smite.h
+++ b/src/smite.h
@@ -15,6 +15,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <inttypes.h>
+#include <byteswap.h>
 
 
 // Build-time parameters
@@ -177,6 +178,14 @@ _GL_ATTRIBUTE_PURE static inline uint8_t *native_address_of_range(smite_state *S
     return ((uint8_t *)(S->memory)) + addr;
 }
 
+#if WORD_BYTES == 4
+#define reverse_endianness bswap_32
+#elif WORD_BYTES == 8
+#define reverse_endianness bswap_64
+#else
+#error "WORD_BYTES must be 4 or 8!"
+#endif
+
 static inline int load(smite_state *S, smite_UWORD addr, unsigned size, smite_WORD *val_ptr)
 {
     if (addr >= S->memory_size) {
@@ -188,22 +197,31 @@ static inline int load(smite_state *S, smite_UWORD addr, unsigned size, smite_WO
         return SMITE_ERR_MEMORY_UNALIGNED;
     }
 
+    smite_WORD val;
     switch (size) {
     case 0:
-        *val_ptr = (smite_UWORD)((uint8_t *)S->memory)[addr];
+        val = (smite_UWORD)((uint8_t *)S->memory)[addr];
         break;
     case 1:
-        *val_ptr = (smite_UWORD)((uint16_t *)S->memory)[addr / 2];
+        val = (smite_UWORD)((uint16_t *)S->memory)[addr / 2];
+        if (ENDISM != DEFAULT_ENDISM)
+            val = bswap_16(val);
         break;
     case 2:
-        *val_ptr = (smite_UWORD)((uint32_t *)S->memory)[addr / 4];
+        val = (smite_UWORD)((uint32_t *)S->memory)[addr / 4];
+        if (ENDISM != DEFAULT_ENDISM)
+            val = bswap_32(val);
         break;
     case 3:
-        *val_ptr = (smite_UWORD)((uint64_t *)S->memory)[addr / 8];
+        val = (smite_UWORD)((uint64_t *)S->memory)[addr / 8];
+        if (ENDISM != DEFAULT_ENDISM)
+            val = bswap_64(val);
         break;
     default:
         return SMITE_ERR_BAD_SIZE;
     }
+
+    *val_ptr = val;
     return SMITE_ERR_OK;
 }
 
@@ -223,17 +241,24 @@ static inline int store(smite_state *S, smite_UWORD addr, unsigned size, smite_W
         ((uint8_t *)S->memory)[addr] = (uint8_t)val;
         break;
     case 1:
+        if (ENDISM != DEFAULT_ENDISM)
+            val = bswap_16(val);
         ((uint16_t *)S->memory)[addr / 2] = (uint16_t)val;
         break;
     case 2:
+        if (ENDISM != DEFAULT_ENDISM)
+            val = bswap_32(val);
         ((uint32_t *)S->memory)[addr / 4] = (uint32_t)val;
         break;
     case 3:
+        if (ENDISM != DEFAULT_ENDISM)
+            val = bswap_64(val);
         ((uint64_t *)S->memory)[addr / 8] = (uint64_t)val;
         break;
     default:
         return SMITE_ERR_BAD_SIZE;
     }
+
     return SMITE_ERR_OK;
 }
 

--- a/src/smite.h
+++ b/src/smite.h
@@ -17,11 +17,22 @@
 #include <inttypes.h>
 
 
-// Types and printf formats
+// Build-time parameters
 #define DEFAULT_WORD_BYTES SIZEOF_SIZE_T
 #ifndef WORD_BYTES
 #define WORD_BYTES DEFAULT_WORD_BYTES
 #endif
+
+#ifndef WORDS_BIGENDIAN
+#define DEFAULT_ENDISM 0
+#else
+#define DEFAULT_ENDISM 1
+#endif
+#ifndef ENDISM
+#define ENDISM DEFAULT_ENDISM
+#endif
+
+// Types and printf formats
 typedef uint8_t smite_BYTE;
 #if WORD_BYTES == 4
 typedef int32_t smite_WORD;
@@ -53,6 +64,7 @@ typedef smite_WORD * smite_WORDP;
 
 // Constants
 extern const unsigned smite_word_bytes;
+extern const unsigned smite_endism;
 extern const unsigned smite_size_word;
 #define smite_BYTE_BIT 8
 extern const unsigned smite_byte_bit;

--- a/src/smite.h
+++ b/src/smite.h
@@ -104,8 +104,8 @@ typedef struct {
 // Instructions
 #define SMITE_INSTRUCTION_BIT 8
 #define SMITE_INSTRUCTION_MASK ((1 << SMITE_INSTRUCTION_BIT) - 1)
-extern const smite_UWORD smite_instruction_bit;
-extern const smite_UWORD smite_instruction_mask;
+extern const unsigned smite_instruction_bit;
+extern const unsigned smite_instruction_mask;
 
 // Errors
 enum {

--- a/src/smite_core/vm_data.py
+++ b/src/smite_core/vm_data.py
@@ -24,7 +24,6 @@ class Registers(Enum):
     I = Register()
     BAD = Register()
     STACK_DEPTH = Register()
-    ENDISM = Register(read_only=True)
 
 @unique
 class Instructions(Enum):

--- a/src/storage.c
+++ b/src/storage.c
@@ -18,6 +18,7 @@
 
 // Constants
 const unsigned smite_word_bytes = WORD_BYTES;
+const unsigned smite_endism = ENDISM;
 const unsigned smite_size_word = smite_SIZE_WORD;
 const unsigned smite_byte_bit = 8;
 const unsigned smite_byte_mask = smite_BYTE_MASK;
@@ -127,13 +128,6 @@ smite_state *smite_init(size_t memory_size, size_t stack_size)
     if (smite_realloc_stack(S, stack_size) != 0)
         return NULL;
 
-    S->ENDISM =
-#ifdef WORDS_BIGENDIAN
-        1
-#else
-        0
-#endif
-        ;
     S->PC = 0;
     S->BAD = 0;
     S->STACK_DEPTH = 0;

--- a/src/storage.c
+++ b/src/storage.c
@@ -23,12 +23,12 @@ const unsigned smite_size_word = smite_SIZE_WORD;
 const unsigned smite_byte_bit = 8;
 const unsigned smite_byte_mask = smite_BYTE_MASK;
 const unsigned smite_word_bit = smite_WORD_BIT;
+const unsigned smite_instruction_bit = SMITE_INSTRUCTION_BIT;
+const unsigned smite_instruction_mask = SMITE_INSTRUCTION_MASK;
 const smite_UWORD smite_word_mask = smite_WORD_MASK;
 const smite_UWORD smite_uword_max = smite_UWORD_MAX;
 const smite_WORD smite_word_min = smite_WORD_MIN;
 const smite_WORD smite_word_max = smite_WORD_MAX;
-const smite_UWORD smite_instruction_bit = SMITE_INSTRUCTION_BIT;
-const smite_UWORD smite_instruction_mask = SMITE_INSTRUCTION_MASK;
 
 
 // Utility functions

--- a/src/storage.c
+++ b/src/storage.c
@@ -23,12 +23,12 @@ const unsigned smite_size_word = smite_SIZE_WORD;
 const unsigned smite_byte_bit = 8;
 const unsigned smite_byte_mask = smite_BYTE_MASK;
 const unsigned smite_word_bit = smite_WORD_BIT;
-const unsigned smite_instruction_bit = SMITE_INSTRUCTION_BIT;
-const unsigned smite_instruction_mask = SMITE_INSTRUCTION_MASK;
 const smite_UWORD smite_word_mask = smite_WORD_MASK;
 const smite_UWORD smite_uword_max = smite_UWORD_MAX;
 const smite_WORD smite_word_min = smite_WORD_MIN;
 const smite_WORD smite_word_max = smite_WORD_MAX;
+const unsigned smite_instruction_bit = SMITE_INSTRUCTION_BIT;
+const unsigned smite_instruction_mask = SMITE_INSTRUCTION_MASK;
 
 
 // Utility functions

--- a/src/storage.c
+++ b/src/storage.c
@@ -128,7 +128,7 @@ smite_state *smite_init(size_t memory_size, size_t stack_size)
         return NULL;
 
     S->ENDISM =
-#ifdef smite_WORDS_BIGENDIAN
+#ifdef WORDS_BIGENDIAN
         1
 #else
         0

--- a/tests/load_object.py
+++ b/tests/load_object.py
@@ -22,9 +22,9 @@ def try_load(file):
     return ret
 
 def obj_name(prefix, file, word_bytes=None, use_endism=True):
-    endism = "-{}".format("le" if ENDISM.get() == 0 else "be")
+    endism_str = "-{}".format("le" if endism == 0 else "be")
     suffix = "-{}".format(word_bytes) if word_bytes else ""
-    name = "{}/{}{}{}".format(prefix, file, endism if use_endism else "", suffix)
+    name = "{}/{}{}{}".format(prefix, file, endism_str if use_endism else "", suffix)
     return name
 
 src_dir = os.environ['srcdir']

--- a/tests/memory.py
+++ b/tests/memory.py
@@ -19,97 +19,69 @@ VM.globalize(globals())
 magic_number = 0xf201
 correct = [
     [],
-    [size * word_bytes],
-    [size * word_bytes, word_bytes],
-    [size * word_bytes, -word_bytes],
-    [size * word_bytes - word_bytes],
-    [size * word_bytes - word_bytes, magic_number],
-    [size * word_bytes - word_bytes, magic_number, 1],
-    [size * word_bytes - word_bytes, magic_number, size * word_bytes - word_bytes],
-    [size * word_bytes - word_bytes, magic_number, size * word_bytes - word_bytes, size_word],
-    [size * word_bytes - word_bytes],
-    [size * word_bytes - word_bytes, 0],
-    [size * word_bytes - word_bytes, size * word_bytes - word_bytes],
-    [size * word_bytes - word_bytes, size * word_bytes - word_bytes, size_word],
-    [size * word_bytes - word_bytes, magic_number],
-    [size * word_bytes - word_bytes, magic_number, 1],
-    [size * word_bytes - word_bytes],
-    [size * word_bytes - word_bytes, 0],
-    [size * word_bytes - word_bytes, size * word_bytes - word_bytes],
-    [size * word_bytes - word_bytes, size * word_bytes - word_bytes, 1],
-    [size * word_bytes - word_bytes, magic_number & 0xffff],
-    [size * word_bytes - word_bytes, magic_number, 1],
-    [size * word_bytes - word_bytes],
-    [size * word_bytes - word_bytes, 0],
-    [size * word_bytes - word_bytes, size * word_bytes - word_bytes],
-    [size * word_bytes - word_bytes, size * word_bytes - word_bytes, 1],
-    [size * word_bytes - word_bytes, magic_number],
-    [size * word_bytes - word_bytes, magic_number, 1],
-    [size * word_bytes - word_bytes, magic_number | -0x10000],
-    [size * word_bytes - word_bytes, magic_number | -0x10000, 1],
-    [size * word_bytes - word_bytes],
-    [size * word_bytes - word_bytes, 0],
-    [size * word_bytes - word_bytes, size * word_bytes - word_bytes],
-    [size * word_bytes - word_bytes, size * word_bytes - word_bytes, 0],
-    [size * word_bytes - word_bytes, 1],
-    [size * word_bytes - word_bytes + 1],
-    [size * word_bytes - word_bytes + 1, 0],
+    [magic_number],
+    [magic_number, (size - 1) * word_bytes],
+    [magic_number, (size - 1) * word_bytes, size_word],
+    [],
+    [(size - 1) * word_bytes],
+    [(size - 1) * word_bytes, size_word],
+    [magic_number],
+    [magic_number, 1],
+    [],
+    [(size - 1) * word_bytes + (word_bytes - 2) * endism],
+    [(size - 1) * word_bytes + (word_bytes - 2) * endism, 1],
+    [magic_number],
+    [magic_number, 1],
+    [],
+    [(size - 1) * word_bytes + (word_bytes - 2) * endism],
+    [(size - 1) * word_bytes + (word_bytes - 2) * endism, 1],
+    [magic_number],
+    [magic_number, 1],
+    [magic_number | -0x10000],
+    [magic_number | -0x10000, 1],
+    [],
+    [(size - 1) * word_bytes + (word_bytes - 2) * endism + 1 * (1 - endism)],
+    [(size - 1) * word_bytes + (word_bytes - 2) * endism + 1 * (1 - endism), 0],
     [0xf2],
-    [0xf2, size * word_bytes - 1],
-    [0xf2, size * word_bytes - 1, 0],
+    [0xf2, size * word_bytes - ((word_bytes - 1) * endism + 1)],
+    [0xf2, size * word_bytes - ((word_bytes - 1) * endism + 1), 0],
     [],
-    [size * word_bytes - word_bytes],
-    [size * word_bytes - word_bytes, size_word],
+    [(size - 1) * word_bytes],
+    [(size - 1) * word_bytes, size_word],
     [(0xf2 << (word_bit - byte_bit)) | magic_number | -(word_mask + 1)],
-    [(0xf2 << (word_bit - byte_bit)) | magic_number | -(word_mask + 1), 1],
-    [],
 ]
 
 # Test code
-lit(size * word_bytes)
-lit(word_bytes)
-ass(NEGATE)
-ass(ADD)
 lit(magic_number)
-lit(1)
-ass(DUP)
+lit((size - 1) * word_bytes)
 lit(size_word)
 ass(STORE)
-lit(0)
-ass(DUP)
+lit((size - 1) * word_bytes)
 lit(size_word)
 ass(LOAD)
 lit(1)
 ass(POP)
-lit(0)
-ass(DUP)
+lit((size - 1) * word_bytes + (word_bytes - 2) * endism)
 lit(1)
 ass(LOAD)
 lit(1)
 ass(POP)
-lit(0)
-ass(DUP)
+lit((size - 1) * word_bytes + (word_bytes - 2) * endism)
 lit(1)
 ass(LOAD)
 lit(1)
 ass(SIGN_EXTEND)
 lit(1)
 ass(POP)
-lit(0)
-ass(DUP)
-lit(0)
-ass(LOAD)
-ass(ADD)
+lit((size - 1) * word_bytes + (word_bytes - 2) * endism + 1 * (1 - endism))
 lit(0)
 ass(LOAD)
-lit(size * word_bytes - 1)
+lit(size * word_bytes - ((word_bytes - 1) * endism + 1))
 lit(0)
 ass(STORE)
-lit(size * word_bytes - word_bytes)
+lit((size - 1) * word_bytes)
 lit(size_word)
 ass(LOAD)
-lit(1)
-ass(POP)
 
 # Test
 run_test("memory", VM, correct)


### PR DESCRIPTION
Make the interface for building different word sizes and endiannesses
regular, and test all combinations.

Display endianness and word size in version banner.

Other small, mostly related, fixes.