### PR TITLE
Fix multi-word push/pop

### DIFF
--- a/src/include/smite/smite.h
+++ b/src/include/smite/smite.h
@@ -305,20 +305,25 @@ int smite_push_stack(smite_state *S, smite_WORD val);
 
 // Convenience macros for native types
 #define PUSH_STACK_TYPE(S, ty, v)                                       \
-    for (unsigned i = 0; i < align(sizeof(ty), smite_SIZE_WORD); i++) { \
-        int ret = push_stack(S, (smite_UWORD)((size_t)(v) & smite_word_mask)); \
-        if (ret != 0)                                                   \
-            RAISE(ret);                                                 \
-        v = (ty)((size_t)(v) >> smite_word_bit);                        \
+    {                                                                   \
+        size_t temp = v;                                                \
+        for (unsigned i = 0; i < align(sizeof(ty), smite_SIZE_WORD) / WORD_BYTES; i++) { \
+            int ret = push_stack(S, (smite_UWORD)(temp & smite_WORD_MASK)); \
+            if (ret != 0)                                               \
+                RAISE(ret);                                             \
+            temp >>= smite_WORD_BIT;                                    \
     }
 #define POP_STACK_TYPE(S, ty, v)                                        \
-    *(v) = 0;                                                           \
-    for (unsigned i = 0; i < align(sizeof(ty), smite_SIZE_WORD); i++) { \
-        smite_WORD w;                                                   \
-        int ret = pop_stack(S, &w);                                     \
-        if (ret != 0)                                                   \
-            RAISE(ret);                                                 \
-        *(v) = (ty)(((size_t)(*v) << smite_word_bit) | (smite_UWORD)w); \
+    {                                                                   \
+        size_t temp = 0;                                                \
+        for (unsigned i = 0; i < align(sizeof(ty), smite_SIZE_WORD) / WORD_BYTES; i++) { \
+            smite_WORD w;                                               \
+            int ret = pop_stack(S, &w);                                 \
+            if (ret != 0)                                               \
+                RAISE(ret);                                             \
+            temp = (temp << smite_WORD_BIT) | (smite_UWORD)w;           \
+        }                                                               \
+        *(v) = (ty)temp;                                                \
     }
 
 

--- a/src/smite_core/instruction.py
+++ b/src/smite_core/instruction.py
@@ -49,4 +49,3 @@ class AbstractInstruction(Enum):
                 instruction.opcode,
             ))
         print('};')
-

--- a/src/smite_core/instruction_gen.py
+++ b/src/smite_core/instruction_gen.py
@@ -381,4 +381,3 @@ def dispatch(instructions, prefix, undefined_case):
     )
     # Remove newlines resulting from empty strings in the above.
     return re.sub('\n+', '\n', '\n'.join(code), flags=re.MULTILINE).strip('\n')
-

--- a/src/smite_core/instruction_gen.py
+++ b/src/smite_core/instruction_gen.py
@@ -138,21 +138,20 @@ class StackItem:
     def __hash__(self):
         return hash((self.name, self.type, self.size))
 
-    # In `load()` & `store()`, casts to size_t avoid warnings when `type` is
-    # a pointer and sizeof(void *) > WORD_BYTES, but the effect is identical.
+    # Cf. smite.h PUSH/POP_STACK_TYPE macros.
     def load(self):
         '''
         Returns C source code to load `self` from the stack to its C variable.
         '''
         code = [
             'size_t temp = (smite_UWORD)(*UNCHECKED_STACK({}));'
-            .format(self.depth + (self.size - 1))
+            .format(self.depth)
         ]
-        for i in reversed(range(self.size - 1)):
+        for i in range(self.size - 1):
             code.append('temp <<= smite_WORD_BIT;')
             code.append(
                 'temp |= (smite_UWORD)(*UNCHECKED_STACK({}));'
-                .format(self.depth + i)
+                .format(self.depth + i + 1)
             )
         code.append('{} = ({})temp;'.format(self.name, self.type))
         return '''\
@@ -165,15 +164,15 @@ class StackItem:
         Returns C source code to store `self` to the stack from its C variable.
         '''
         code = ['size_t temp = (size_t){};'.format(self.name)]
-        for i in range(self.size - 1):
+        for i in reversed(range(self.size - 1)):
             code.append(
                 '*UNCHECKED_STACK({}) = (smite_UWORD)(temp & smite_WORD_MASK);'
-                .format(self.depth + i)
+                .format(self.depth + i + 1)
             )
             code.append('temp >>= smite_WORD_BIT;')
         code.append(
             '*UNCHECKED_STACK({}) = (smite_UWORD)(temp & smite_WORD_MASK);'
-            .format(self.depth + (self.size - 1))
+            .format(self.depth)
         )
         return '''\
 {{


### PR DESCRIPTION
The PUSH/POP_STACK_TYPE macros were pushing and popping the words in the
opposite order from the code generated by instruction_gen.py. (Also, they
were pushing and popping the wrong number of words, oops.)

Standardize on pushing the least-significant word first.