### PR TITLE
Express aliasing guarantees (#116)

### DIFF
--- a/src/features/auto-extend.c
+++ b/src/features/auto-extend.c
@@ -35,7 +35,7 @@ mit_state *mit_auto_extend_init(void)
     return mit_init(memory_size, stack_size);
 }
 
-int mit_auto_extend_handler(mit_state *S, int error)
+int mit_auto_extend_handler(mit_state * restrict S, int error)
 {
     switch (error) {
     case 2:

--- a/src/features/gen-extra-instructions
+++ b/src/features/gen-extra-instructions
@@ -41,7 +41,7 @@ enum {
 
 for lib in LibInstruction:
     print('''\
-static mit_WORD extra_{}(mit_state *S, mit_WORD opcode)
+static mit_WORD extra_{}(mit_state * restrict S, mit_WORD opcode)
 {{'''.format(str.lower(lib.name)))
     print(dispatch(
         lib.library,
@@ -53,7 +53,7 @@ static mit_WORD extra_{}(mit_state *S, mit_WORD opcode)
 ''')
 
 print('''
-mit_WORD mit_extra_instruction(mit_state *S, mit_UWORD opcode)
+mit_WORD mit_extra_instruction(mit_state * restrict S, mit_UWORD opcode)
 {''')
 
 print(dispatch(

--- a/src/features/gen-specializer
+++ b/src/features/gen-specializer
@@ -97,7 +97,7 @@ print('''\
         S->I >>= MIT_INSTRUCTION_BIT;                         \\
     } while (0)
 
-mit_WORD mit_specializer_run(mit_state *S) {
+mit_WORD mit_specializer_run(mit_state * restrict S) {
     int res = MIT_ERR_OK;''')
 
 # Declare stack cache variables.

--- a/src/features/mit/features.h.in
+++ b/src/features/mit/features.h.in
@@ -17,9 +17,9 @@
 
 #include <stdio.h>
 
-mit_WORD mit_extra_instruction(mit_state *S, mit_UWORD opcode);
+mit_WORD mit_extra_instruction(mit_state * restrict S, mit_UWORD opcode);
 mit_state *mit_auto_extend_init(void);
-int mit_auto_extend_handler(mit_state *S, int error);
+int mit_auto_extend_handler(mit_state * restrict S, int error);
 int mit_core_dump(mit_state *S);
 mit_WORD mit_specializer_run(mit_state * restrict S);
 mit_WORD mit_trace_run(mit_state *state, FILE * restrict trace_fp);

--- a/src/features/mit/features.h.in
+++ b/src/features/mit/features.h.in
@@ -21,7 +21,7 @@ mit_WORD mit_extra_instruction(mit_state *S, mit_UWORD opcode);
 mit_state *mit_auto_extend_init(void);
 int mit_auto_extend_handler(mit_state *S, int error);
 int mit_core_dump(mit_state *S);
-mit_WORD mit_specializer_run(mit_state *S);
-mit_WORD mit_trace_run(mit_state *state, FILE *trace_fp);
+mit_WORD mit_specializer_run(mit_state * restrict S);
+mit_WORD mit_trace_run(mit_state *state, FILE * restrict trace_fp);
 
 #endif

--- a/src/features/trace.c
+++ b/src/features/trace.c
@@ -15,7 +15,7 @@
 #include "mit/features.h"
 
 
-mit_WORD mit_trace_run(mit_state *state, FILE *trace_fp)
+mit_WORD mit_trace_run(mit_state * restrict state, FILE *trace_fp)
 {
     int ret = 0;
     do {

--- a/src/gen-instructions
+++ b/src/gen-instructions
@@ -42,7 +42,7 @@ print('''\
         S->PC += mit_WORD_BYTES;                              \\
     } while (0)
 
-mit_WORD mit_single_step(mit_state *S) {
+mit_WORD mit_single_step(mit_state * restrict S) {
     mit_UWORD initial_PC = S->PC;
     mit_UWORD initial_I = S->I;
     mit_BYTE opcode = S->I & MIT_INSTRUCTION_MASK;
@@ -66,7 +66,7 @@ print('''
 }
 
 
-mit_WORD mit_run(mit_state *S)
+mit_WORD mit_run(mit_state * restrict S)
 {
     mit_WORD ret;
     while ((ret = mit_single_step(S)) == 0)

--- a/src/include/mit/mit.h.in
+++ b/src/include/mit/mit.h.in
@@ -94,9 +94,9 @@ typedef struct {
 #include <mit@PACKAGE_SUFFIX@/registers.h>
 #undef R
 #undef R_RO
-    mit_WORD *memory;
+    mit_WORD * restrict memory;
     mit_UWORD memory_size;
-    mit_WORD *stack;
+    mit_WORD * restrict stack;
     mit_UWORD stack_size;
     int main_argc;
     char **main_argv;
@@ -423,12 +423,12 @@ int mit_realloc_stack(mit_state *S, mit_UWORD stack_size);
 void mit_destroy(mit_state *S);
 /* Destroy the given state, deallocating its memory. */
 
-mit_WORD mit_run(mit_state *S);
+mit_WORD mit_run(mit_state * restrict S);
 /* Start the execution cycle in the given state as described in the spec.
    If an error is raised, the code is returned.
 */
 
-mit_WORD mit_single_step(mit_state *S);
+mit_WORD mit_single_step(mit_state * restrict S);
 /* Execute a single pass of the execution cycle in the given state.
    Return 128 if execution completes without error, or the error code.
 */

--- a/src/storage.c
+++ b/src/storage.c
@@ -87,9 +87,9 @@ int mit_push_stack(mit_state *S, mit_WORD val)
 
 // Initialisation and memory management
 
-static int mit_realloc(mit_WORD **ptr, mit_UWORD old_size, mit_UWORD new_size)
+static int mit_realloc(mit_WORD * restrict *ptr, mit_UWORD old_size, mit_UWORD new_size)
 {
-    mit_WORD *new_ptr = realloc(*ptr, new_size * mit_WORD_BYTES);
+    mit_WORD * restrict new_ptr = realloc(*ptr, new_size * mit_WORD_BYTES);
     if (new_ptr == NULL && new_size > 0)
         return -1;
     *ptr = new_ptr;


### PR DESCRIPTION
Mark `S` as "restrict" in `mit_single_step()` and `mit_run()`.
Also in `mit_run_specialized` and `mit_run_trace`.

I decided it was pointless to do the same in the static inline functions in "mit.h".
If they are inlined it is unnecessary, and if they are not it is futile.

mit.h: Mark `memory` and `stack` as "restrict" in "struct mit_state".
storage.c: smite_realloc: Add "restrict" to fix warnings.

Performance: No measurable difference. This is a little surprising.