### PR TITLE
Improve instruction dispatch in “naive interpreter”

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,7 @@ LIB_CORE_SRCS = \
 	mit_core/vm_data.py \
 	mit_core/errors.py \
 	mit_core/code_buffer.py \
+	mit_core/opcode_frequency.py \
 	mit_core/instruction_gen.py
 nodist_libmit@PACKAGE_SUFFIX@_la_SOURCES = $(C_SRCS) $(nodist_LIB_SRCS)
 libmit@PACKAGE_SUFFIX@_la_LIBADD = $(top_builddir)/lib/libgnu.la
@@ -71,8 +72,8 @@ include/mit/opcodes.h: gen-opcodes mit_core/vm_data.py mit_core/instruction.py
 	$(MKDIR_P) include/mit
 	$(PYTHON_WITH_PATH) $(srcdir)/gen-opcodes > include/mit/opcodes.h || ( rm -f include/mit/opcodes.h; exit 1 )
 
-instructions.c: gen-instructions mit_core/vm_data.py mit_core/instruction.py mit_core/code_buffer.py mit_core/instruction_gen.py
-	$(PYTHON_WITH_PATH) $(srcdir)/gen-instructions > instructions.c || ( rm -f instructions.c; exit 1 )
+instructions.c: gen-instructions mit_core/vm_data.py mit_core/instruction.py mit_core/code_buffer.py mit_core/instruction_gen.py features/instructions.trace.gz
+	$(PYTHON_WITH_PATH) $(srcdir)/gen-instructions $(srcdir)/features/instructions.trace.gz > instructions.c || ( rm -f instructions.c; exit 1 )
 
 main.c: gen-main
 	$(PYTHON_WITH_PATH) $(srcdir)/gen-main > main.c || ( rm -f main.c; exit 1 )

--- a/src/features/features.am
+++ b/src/features/features.am
@@ -110,7 +110,8 @@ EXTRA_DIST += \
 	%D%/gen-labels \
 	%D%/gen-predictor \
 	%D%/gen-specializer \
-	%D%/instructions.trace.gz
+	%D%/instructions.trace.gz \
+	%D%/opcode-frequency
 
 DISTCLEANFILES += \
 	%D%/instructions.predictor_pickle \

--- a/src/features/opcode-frequency
+++ b/src/features/opcode-frequency
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2018-2019 Mit authors
+#
+# The package is distributed under the MIT/X11 License.
+#
+# THIS PROGRAM IS PROVIDED AS IS, WITH NO WARRANTY. USE IS AT THE USER’S
+# RISK.
+
+import sys
+import gzip
+import argparse
+from pprint import pprint
+
+from mit_core.vm_data import Instruction
+from mit_core import opcode_frequency
+
+
+# Command-line arguments
+parser = argparse.ArgumentParser(
+    prog='opcode-frequency',
+    description='Count the frequency of opcodes or pairs in a trace.',
+)
+parser.add_argument('-n', '--topmost', type=int,
+                    help='maximum number of opcodes/pairs to print')
+parser.add_argument('-p', '--pairs', action='store_true',
+                    help='''calculate frequency of instruction pairs
+                    (default is single instructions)''')
+parser.add_argument('file', metavar='FILE')
+args = parser.parse_args()
+
+# Read trace
+with gzip.open(args.file, 'rb') as f: trace = f.read()
+
+# Compute instruction counts
+if not args.pairs: # Single instructions
+    counts = [(count, instruction.name)
+              for count, instruction in
+              opcode_frequency.counts(Instruction, trace)]
+else: # Instruction pairs
+    counts = [(count, (instruction1.name, instruction2.name))
+              for count, (instruction1, instruction2) in
+              opcode_frequency.pair_counts(Instruction, trace)]
+if args.topmost is not None:
+    counts = counts[:args.topmost]
+
+# Print results
+pprint(counts)

--- a/src/gen-instructions
+++ b/src/gen-instructions
@@ -8,11 +8,24 @@
 # THIS PROGRAM IS PROVIDED AS IS, WITH NO WARRANTY. USE IS AT THE USER’S
 # RISK.
 
+import sys
+import gzip
+
 from mit_core import vm_data, instruction_gen
 
 from mit_core.vm_data import Instruction, InternalExtraInstruction
 from mit_core.code_buffer import Code
 from mit_core.instruction_gen import dispatch, gen_case
+
+
+if len(sys.argv) != 2:
+    print("Usage: gen-instructions TRACE-FILENAME", file=sys.stderr)
+    sys.exit(1)
+
+
+# Read trace
+trace_filename = sys.argv[1]
+with gzip.open(trace_filename, 'rb') as f: trace = f.read()
 
 
 # Write the output file
@@ -79,7 +92,7 @@ body_code.append('''\
 body_code.extend(dispatch(Instruction, 'O_', Code(
     '/* Undefined instruction. */',
     'RAISE(MIT_ERROR_INVALID_OPCODE);',
-)))
+), trace))
 body_code.append('return MIT_ERROR_OK;')
 code.append(body_code)
 

--- a/src/mit_core/instruction_gen.py
+++ b/src/mit_core/instruction_gen.py
@@ -433,22 +433,17 @@ def dispatch(instructions, prefix, undefined_case):
     '''
     assert isinstance(undefined_case, Code)
     code = Code()
-    code.append('switch (opcode) {')
+    else_text = ''
     for instruction in instructions:
-        code.append('case {prefix}{instruction}:'.format(
+        code.append('{else_text}if (opcode == {prefix}{instruction}) {{'.format(
+            else_text=else_text,
             instruction=instruction.name,
             prefix=prefix,
         ))
-        code.extend(Code(
-            '{',
-            gen_case(instruction),
-            '}',
-            'break;',
-        ))
-    code.append('default:')
-    default_code = Code()
-    default_code.extend(undefined_case)
-    default_code.append('break;')
-    code.append(default_code)
+        code.append(gen_case(instruction))
+        code.append('}')
+        else_text = 'else '
+    code.append('else {')
+    code.append(undefined_case)
     code.append('}')
     return code

--- a/src/mit_core/instruction_gen.py
+++ b/src/mit_core/instruction_gen.py
@@ -14,6 +14,7 @@ The main entry point is dispatch().
 import functools
 
 from .code_buffer import Code
+from .opcode_frequency import counts
 
 
 type_wordses = {'mit_word': 1} # Enough for the core
@@ -423,18 +424,22 @@ def gen_case(instruction):
         code.extend(effect.store_results())
     return code
 
-def dispatch(instructions, prefix, undefined_case):
+def dispatch(Instruction, prefix, undefined_case, trace=None):
     '''
     Generate dispatch code for some Instructions.
 
-     - instructions - Enum of Instructions.
-     - prefix - opcode name prefix.
+     - Instruction - AbstractInstruction.
+     - prefix - instruction name prefix.
      - undefined_case - a Code defining the fallback behaviour.
+     - trace - an opcode trace to use to improve the dispatch code.
     '''
     assert isinstance(undefined_case, Code)
     code = Code()
     else_text = ''
-    for instruction in instructions:
+    order = enumerate(Instruction)
+    if trace is not None:
+        order = counts(Instruction, trace)
+    for (_, instruction) in order:
         code.append('{else_text}if (opcode == {prefix}{instruction}) {{'.format(
             else_text=else_text,
             instruction=instruction.name,

--- a/src/mit_core/opcode_frequency.py
+++ b/src/mit_core/opcode_frequency.py
@@ -1,0 +1,45 @@
+'''
+Count the frequency of opcodes or pairs in a trace.
+
+Copyright (c) 2019 Mit authors
+
+The package is distributed under the MIT/X11 License.
+
+THIS PROGRAM IS PROVIDED AS IS, WITH NO WARRANTY. USE IS AT THE USER’S
+RISK.
+'''
+
+def counts(Instruction, trace):
+    '''
+    Returns a list of (count, instruction) sorted by descending count for a
+    trace.
+
+     - Instruction - AbstractInstruction
+     - trace - bytes - opcode values
+    '''
+    counts = {instruction.opcode: 0 for instruction in Instruction}
+    for opcode in trace: counts[opcode] += 1
+    freq = sorted([(count, opcode) for opcode, count in counts.items()],
+                  reverse=True)
+    by_opcode = {instruction.opcode: instruction for instruction in Instruction}
+    return [(count, by_opcode[opcode]) for count, opcode in freq]
+
+def pair_counts(Instruction, trace):
+    '''
+    Returns a list of (count, (instruction1, instruction2)) sorted by
+    descending count for a trace.
+
+     - Instruction - AbstractInstruction
+     - trace - bytes - opcode values
+    '''
+    counts = {(instruction1.opcode, instruction2.opcode): 0
+              for instruction1 in Instruction
+              for instruction2 in Instruction}
+    for opcode1, opcode2 in zip(trace, trace[1:]):
+        counts[(opcode1, opcode2)] += 1
+    freq = sorted([(count, (opcode1, opcode2))
+                   for (opcode1, opcode2), count in counts.items()],
+                  reverse=True)
+    by_opcode = {instruction.opcode: instruction for instruction in Instruction}
+    return [(count, (by_opcode[opcode1], by_opcode[opcode2]))
+            for count, (opcode1, opcode2) in freq]


### PR DESCRIPTION
Use the instruction trace (from the specializer) to derive instruction
frequency counts, and rather than a switch, use a series of ifs with
the instructions ordered by descending frequency.

This gives a 50% speedup for the naive interpreter (without -O).

Also add a script features/opcode-frequency that can analyse a trace for
either instruction frequency or instruction pair frequency.