### PR TITLE
Use “file” rather than “filename” consistently in command-line arguments

### DIFF
--- a/python/mit-dump.in
+++ b/python/mit-dump.in
@@ -14,7 +14,7 @@ import argparse
 import mit@PACKAGE_SUFFIX@
 
 
-# Command-line arguments.
+# Process command-line arguments
 parser = argparse.ArgumentParser(
     prog='mit-dump',
     description='Dump Mit object file as hex and disassembly',
@@ -27,16 +27,17 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-for filename in args.object_file:
-    basename, ext = os.path.splitext(filename)
+# Dump files
+for file in args.object_file:
+    basename, ext = os.path.splitext(file)
 
     VM = mit.State()
-    length = VM.load(filename)
+    length = VM.load(file)
 
-    asm_filename = "{}.asm".format(basename)
-    with open(asm_filename, "w") as h:
+    asm_file = "{}.asm".format(basename)
+    with open(asm_file, "w") as h:
         VM.disassemble(0, length, file=h)
 
-    hex_filename = "{}.hex".format(basename)
-    with open(hex_filename, "w") as h:
+    hex_file = "{}.hex".format(basename)
+    with open(hex_file, "w") as h:
         VM.dump(0, length, file=h)

--- a/src/gen-instructions
+++ b/src/gen-instructions
@@ -27,15 +27,15 @@ parser = argparse.ArgumentParser(
     description='Generate naive interpreter',
 )
 parser.add_argument(
-    'profile_filename',
-    metavar='PROFILE-FILENAME',
+    'profile_file',
+    metavar='PROFILE-FILE',
     help='profile file to use',
 )
 args = parser.parse_args()
 
 
 # Get instruction counts from profile and compute order
-profile.load(args.profile_filename)
+profile.load(args.profile_file)
 instruction_counts = {instruction.opcode: 0 for instruction in Instruction}
 for instruction, count in profile.counts().items():
     instruction_counts[instruction.opcode] += count

--- a/tests/brainfuck
+++ b/tests/brainfuck
@@ -15,16 +15,17 @@ RISK.
 '''
 
 import sys
+
 from mit.globals import *
 
 
 if len(sys.argv) != 2:
     print('''\
-Usage: brainfuck OBJECT-FILENAME
+Usage: brainfuck OBJECT-FILE
 
 Brainfuck source is read from standard input.''', file=sys.stderr)
     sys.exit(1)
-object_filename = sys.argv[1]
+object_file = sys.argv[1]
 
 def inc(): ass(LIT_1); ass(ADD)
 def dec(): ass(LIT_1); ass(NEGATE); ass(ADD)
@@ -74,4 +75,4 @@ except ErrorCode as e:
     else:
         sys.exit(1)
 
-save(object_filename)
+save(object_file)

--- a/tests/run-brainfuck-test
+++ b/tests/run-brainfuck-test
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Run a brainfuck test.
 #
-# (c) Mit authors 2019
+# (c) Mit authors 2019-2020
 #
 # The package is distributed under the MIT/X11 License.
 #
@@ -20,14 +20,14 @@ from redirect_stdout import stdout_redirector
 
 
 if len(sys.argv) != 2:
-    print("Usage: run-brainfuck-test BRAINFUCK-FILENAME", file=sys.stderr)
+    print("Usage: run-brainfuck-test BRAINFUCK-FILE", file=sys.stderr)
     sys.exit(1)
-brainfuck_filename = sys.argv[1]
+brainfuck_file = sys.argv[1]
 
-object_filename = re.sub(".bf$", ".obj", os.path.basename(brainfuck_filename))
-with open(brainfuck_filename, 'rb') as f:
+object_file = re.sub(".bf$", ".obj", os.path.basename(brainfuck_file))
+with open(brainfuck_file, 'rb') as f:
     returncode = subprocess.run(
-        [os.environ['PYTHON'], os.path.join(os.environ['srcdir'], './brainfuck'), object_filename],
+        [os.environ['PYTHON'], os.path.join(os.environ['srcdir'], './brainfuck'), object_file],
         input=f.read(),
     ).returncode
     if returncode == 2:
@@ -35,14 +35,14 @@ with open(brainfuck_filename, 'rb') as f:
     elif returncode != 0:
         raise
 VM = State()
-VM.load(object_filename)
+VM.load(object_file)
 f = io.BytesIO()
 with stdout_redirector(f):
     VM.run()
 output = f.getvalue()
-correct_file = re.sub(".bf$", ".correct", brainfuck_filename)
+correct_file = re.sub(".bf$", ".correct", brainfuck_file)
 correct = open(correct_file, "rb").read()
-os.remove(object_filename)
+os.remove(object_file)
 
 print("Output:\n{}\n\nCorrect:\n{}".format(output,correct))
 assert(output == correct)


### PR DESCRIPTION
This is more obvious to the user.

Don’t change the specializer, as we want to keep that synced with Welly.