### PR TITLE
Make pseudo-registers writable

### DIFF
--- a/python/mit/binding.py.in
+++ b/python/mit/binding.py.in
@@ -184,8 +184,8 @@ libmit.mit_save_object.errcheck = errcheck(SaveErrorCode)
 libmit.mit_new_state.restype = c_void_p
 libmit.mit_new_state.argtypes = [c_size_t, c_size_t]
 
-libmit.mit_destroy.restype = None
-libmit.mit_destroy.argtypes = [c_void_p]
+libmit.mit_free_state.restype = None
+libmit.mit_free_state.argtypes = [c_void_p]
 
 libmit.mit_align.restype = c_uword
 libmit.mit_align.argtypes = [c_uword, c_uint]

--- a/python/mit/state.py
+++ b/python/mit/state.py
@@ -56,7 +56,7 @@ class State:
         return state
 
     def __del__(self):
-        libmit.mit_destroy(self.state)
+        libmit.mit_free_state(self.state)
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/src/features/extra_instructions.py
+++ b/src/features/extra_instructions.py
@@ -243,7 +243,7 @@ mit_lib = {
     'DESTROY': (
         0x5,
         StackEffect.of(['inner_state:mit_state *'], []),
-        Code('mit_destroy(inner_state);'),
+        Code('mit_free_state(inner_state);'),
     ),
 
     'RUN': (

--- a/src/features/extra_instructions.py
+++ b/src/features/extra_instructions.py
@@ -298,17 +298,16 @@ for register in Register:
         len(mit_lib), None, get_code,
     )
 
-    if not register.read_only:
-        set_code = Code()
-        set_code.extend(pop_code)
-        set_code.append('{} value;'.format(register.type))
-        set_code.extend(pop_stack('value', register.type))
-        set_code.append('''\
-            mit_set_{}(inner_state, value);'''.format(register.name),
-        )
-        mit_lib['SET_{}'.format(register.name.upper())] = (
-            len(mit_lib), None, set_code,
-        )
+    set_code = Code()
+    set_code.extend(pop_code)
+    set_code.append('{} value;'.format(register.type))
+    set_code.extend(pop_stack('value', register.type))
+    set_code.append('''\
+        mit_set_{}(inner_state, value);'''.format(register.name),
+    )
+    mit_lib['SET_{}'.format(register.name.upper())] = (
+        len(mit_lib), None, set_code,
+    )
 
 LibMit = InstructionEnum('LibMit', mit_lib)
 LibMit.__doc__ = 'Function codes for the external extra instruction LIBMIT.'

--- a/src/gen-main
+++ b/src/gen-main
@@ -488,7 +488,7 @@ static mit_state *S;
 
 static void exit_function(void)
 {
-    mit_destroy(S);
+    mit_free_state(S);
 }''')
 code.extend(initial_code)
 

--- a/src/gen-main
+++ b/src/gen-main
@@ -267,13 +267,11 @@ Feature(# Register and stack backtrace
         if (error != MIT_ERROR_HALT && backtrace == true) {
             fprintf(stderr, "\\nRegisters:\\n");
             char str[MAX_STACK_ITEM_STRLEN];
-            #define R_RO(name, type, return_type) \\
+            #define R(name, type, return_type) \\
             stack_item_to_str((mit_max_stack_item_t)S->name, sizeof(S->name), &str[0]); \\
             fprintf(stderr, #name "=0x%.*s\\n", (int)(sizeof(S->name) * 2), str);
-            #define R(name, type, return_type) R_RO(name,type, return_type)
             #include "mit/registers.h"
             #undef R
-            #undef R_RO
             if (S->stack_depth <= S->stack_words) {
                 fprintf(stderr, "\\nStack:\\n");
                 mit_uword items = MIN(max_backtrace, S->stack_depth);

--- a/src/gen-registers
+++ b/src/gen-registers
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Generate register list.
 #
-# (c) Mit authors 2019
+# (c) Mit authors 2019-2020
 #
 # The package is distributed under the MIT/X11 License.
 #
@@ -14,12 +14,11 @@ from mit_core.spec import Register
 
 GENERATOR_PROGRAM = 'gen-registers'
 PURPOSE = 'Register list.'
-COPYRIGHT_YEARS = '1994-2019'
+COPYRIGHT_YEARS = '1994-2020'
 
 code = copyright_banner(GENERATOR_PROGRAM, PURPOSE, COPYRIGHT_YEARS)
 code.append('')
 for register in Register:
-    code.append("{}({}, {}, {})".format(
-        'R_RO' if register.read_only else 'R',
+    code.append("R({}, {}, {})".format(
         register.name, register.type, unrestrict(register.type)))
 print(code)

--- a/src/include/mit/mit.h.in
+++ b/src/include/mit/mit.h.in
@@ -117,14 +117,11 @@ enum {
 // VM registers
 typedef struct mit_state mit_state;
 
-#define R_RO(reg, type, return_type)            \
-    return_type mit_get_ ## reg(mit_state *S);
 #define R(reg, type, return_type)                       \
-    R_RO(reg, type, return_type)                        \
+    return_type mit_get_ ## reg(mit_state *S);          \
     void mit_set_ ## reg(mit_state *S, type val);
 #include <mit@PACKAGE_SUFFIX@/registers.h>
 #undef R
-#undef R_RO
 
 // Instructions
 #if MIT_OPCODE_BIT < 5 || MIT_OPCODE_BIT > 8

--- a/src/include/mit/mit.h.in
+++ b/src/include/mit/mit.h.in
@@ -389,8 +389,8 @@ mit_state *mit_new_state(size_t memory_words, size_t stack_words);
    the spec.
 */
 
-void mit_destroy(mit_state *S);
-/* Destroy the given state, deallocating its memory. */
+void mit_free_state(mit_state *S);
+/* Free the given state, deallocating its memory. */
 
 mit_word mit_run(mit_state * restrict S);
 /* Start the execution cycle in the given state as described in the spec.

--- a/src/mit_core/spec.py
+++ b/src/mit_core/spec.py
@@ -23,17 +23,16 @@ with open(os.path.join(os.path.dirname(__file__), 'mit_spec.yaml')) as f:
 
 
 class RegisterEnum(AutoNumber):
-    def __init__(self, read_only=False, type='mit_uword'):
-        self.read_only = read_only
+    def __init__(self, type='mit_uword'):
         self.type = type
 
 register = {r: () for r in spec['Register']}
 register.update({
     # Registers that are not part of the spec
-    'memory': (True, 'mit_word *'),
-    'stack': (True, 'mit_word * restrict'),
-    'memory_words': (True,),
-    'stack_words': (True,),
+    'memory': ('mit_word *'),
+    'stack': ('mit_word * restrict'),
+    'memory_words': (),
+    'stack_words': (),
 })
 Register = unique(RegisterEnum('Register', register))
 Register.__doc__ = 'VM registers.'

--- a/src/state.h
+++ b/src/state.h
@@ -1,6 +1,6 @@
 // Declaration of mit_state.
 //
-// (c) Mit authors 2019
+// (c) Mit authors 2019-2020
 //
 // The package is distributed under the MIT/X11 License.
 //
@@ -13,10 +13,8 @@
 
 struct mit_state {
 #define R(reg, type, return_type) type reg;
-#define R_RO(reg, type, return_type) type reg;
 #include "mit/registers.h"
 #undef R
-#undef R_RO
 };
 
 #endif

--- a/src/storage.c
+++ b/src/storage.c
@@ -121,7 +121,7 @@ mit_state *mit_new_state(size_t memory_words, size_t stack_words)
     return S;
 }
 
-void mit_destroy(mit_state *S)
+void mit_free_state(mit_state *S)
 {
     free(S->memory);
     free(S->stack);

--- a/src/storage.c
+++ b/src/storage.c
@@ -128,16 +128,12 @@ void mit_free_state(mit_state *S)
     free(S);
 }
 
-#define R_RO(reg, type, return_type)                                \
+#define R(reg, type, return_type)                                   \
     _GL_ATTRIBUTE_PURE return_type mit_get_ ## reg(mit_state *S) {  \
         return S->reg;                                              \
-    }
-
-#define R(reg, type, return_type)                                   \
-    R_RO(reg, type, return_type)                                    \
+    }                                                               \
     void mit_set_ ## reg(mit_state *S, type val) {                  \
         S->reg = val;                                               \
     }
 #include "mit/registers.h"
 #undef R
-#undef R_RO


### PR DESCRIPTION
This allows memory and stack to be resized, now that the dedicated APIs for
that have been removed. It also allows memory and/or stack to be shared
between states. Not necessarily a good idea, but allows some shortcuts.

Also the code is simplified overall.