### PR TITLE
features/extra_instructions.py: rename DESTROY to FREE_STATE

### DIFF
--- a/src/features/extra_instructions.py
+++ b/src/features/extra_instructions.py
@@ -240,7 +240,7 @@ mit_lib = {
         '''),
     ),
 
-    'DESTROY': (
+    'FREE_STATE': (
         0x5,
         StackEffect.of(['inner_state:mit_state *'], []),
         Code('mit_free_state(inner_state);'),


### PR DESCRIPTION
Match the renaming of the corresponding C API mit_free_state.