### PR TITLE
mit_core/stack.py: fix bug in push_stack

### DIFF
--- a/src/features/extra_instructions.py
+++ b/src/features/extra_instructions.py
@@ -223,8 +223,7 @@ mit_lib.update({
         ),
         Code('''\
             value = 0;
-            ret = load(inner_state->memory, inner_state->memory_words * MIT_WORD_BYTES,
-                       addr, size, &value);
+            ret = mit_load(inner_state, addr, size, &value);
         '''),
     ),
 
@@ -233,9 +232,45 @@ mit_lib.update({
             ['value', 'addr', 'size', 'inner_state:mit_state *'],
             ['ret:int'],
         ),
+        Code('ret = mit_store(inner_state, addr, size, value);'),
+    ),
+
+    'LOAD_STACK': (
+        StackEffect.of(
+            ['pos', 'inner_state:mit_state *'],
+            ['value', 'ret:int'],
+        ),
         Code('''\
-             ret = store(inner_state->memory, inner_state->memory_words * MIT_WORD_BYTES,
-                         addr, size, value);'''),
+            value = 0;
+            ret = mit_load_stack(inner_state, pos, &value);
+        '''),
+    ),
+
+    'STORE_STACK': (
+        StackEffect.of(
+            ['value', 'pos', 'inner_state:mit_state *'],
+            ['ret:int'],
+        ),
+        Code('ret = mit_store_stack(inner_state, pos, value);'),
+    ),
+
+    'POP_STACK': (
+        StackEffect.of(
+            ['inner_state:mit_state*'],
+            ['value', 'ret:int'],
+        ),
+        Code('''\
+            value = 0;
+            ret = mit_pop_stack(inner_state, &value);
+        ''')
+    ),
+
+    'PUSH_STACK': (
+        StackEffect.of(
+            ['value', 'inner_state:mit_state *'],
+            ['ret:int'],
+        ),
+        Code('ret = mit_push_stack(inner_state, value);'),
     ),
 
     'NEW_STATE': (

--- a/src/include/mit/mit.h.in
+++ b/src/include/mit/mit.h.in
@@ -334,7 +334,7 @@ int mit_pop_stack(mit_state *S, mit_word *val_ptr);
  */
 
 int mit_push_stack(mit_state *S, mit_word val);
-/* Increment `stack_depth`, then store the word `val` value at position 0 on
+/* Increment `stack_depth`, then store the word `val` at position 0 on
    the stack.
 
    Return 0 if OK, or error code if `stack_depth` is greater than or equal

--- a/src/mit_core/stack.py
+++ b/src/mit_core/stack.py
@@ -88,18 +88,14 @@ def pop_stack(name, type='mit_word'):
     code = Code()
     code.extend(check_underflow(Size(type_words(type))))
     code.extend(load_stack(name, type=type))
-    code.append(
-        'S->stack_depth -= {};'.format(type_words(type)),
-    )
+    code.append('S->stack_depth -= {};'.format(type_words(type)))
     return code
 
 def push_stack(value, type='mit_word'):
     code = Code()
     code.extend(check_overflow(Size(0), Size(type_words(type))))
+    code.append('S->stack_depth += {};'.format(type_words(type)))
     code.extend(store_stack(value, type=type))
-    code.append(
-        'S->stack_depth += {};'.format(type_words(type)),
-    )
     return code
 
 


### PR DESCRIPTION
The bug was not detected because the only use (for extra instructions) was
not tested or used. The items were being written to the stack before
adjusting the stack pointer, hence corrupting memory below the
stack (typically, malloc information).