### PR TITLE
Use MIT_ERROR_OK consistently to mean “normal termination” (fix #372)

### DIFF
--- a/python/mit/state.py
+++ b/python/mit/state.py
@@ -262,7 +262,7 @@ class BreakHandler:
                 error = self.final_callback(self, stack)
                 if error is not None:
                     return error
-            return enums.MitErrorCode.OK
+            return enums.MitErrorCode.BREAK
 
         if self.trace:
             self.log(f"{stack}")
@@ -272,4 +272,4 @@ class BreakHandler:
             if error is not None:
                 return error
         self.done += 1
-        return enums.MitErrorCode.BREAK
+        return enums.MitErrorCode.OK

--- a/src/gen-instructions
+++ b/src/gen-instructions
@@ -54,7 +54,7 @@ code.append('MIT_THREAD_LOCAL mit_fn_t *mit_break_fn = NULL;')
 code.extend(run_inner_fn('break', Code('''\
         if (mit_break_fn != NULL) {
             error = mit_break_fn(pc, ir, stack, stack_words, &stack_depth);
-            if (error != MIT_ERROR_BREAK)
+            if (error != MIT_ERROR_OK)
                 THROW(error);
         }
 ''')))

--- a/src/run.h.in
+++ b/src/run.h.in
@@ -58,10 +58,10 @@
         goto error;                                           \
     } while (0)
 
-// We must not return 0 with longjmp(), so instead return MIT_ERROR_BREAK,
-// which cannot be returned by `mit_run()`.
+// We must not return 0 with longjmp(), so instead return MIT_ERROR_OK_LONGJMP,
+// which is not returned by `mit_run()`.
 #define THROW_LONGJMP(error)                                    \
-    longjmp(*jmp_buf_ptr, error ? error : MIT_ERROR_BREAK);
+    longjmp(*jmp_buf_ptr, error ? error : MIT_ERROR_OK_LONGJMP);
 
 // Perform the action of `next`.
 #define DO_NEXT                                 \

--- a/src/run_fn.py
+++ b/src/run_fn.py
@@ -79,8 +79,7 @@ def run_fn(suffix):
             if (error == 0) {{
                 run_inner_{suffix}(pc, ir, stack, stack_words, stack_depth_ptr, &env);
                 error = MIT_ERROR_OK;
-            }} else if (error == MIT_ERROR_BREAK)
-                // Translate MIT_ERROR_BREAK as 0; see THROW_LONGJMP in run.h.
+            }} else if (error == MIT_ERROR_OK_LONGJMP) // see THROW_LONGJMP in run.h.in
                 error = 0;
             return error;
         }}

--- a/src/spec.py
+++ b/src/spec.py
@@ -45,7 +45,8 @@ class MitErrorCode(IntEnum):
     INVALID_MEMORY_WRITE = -6
     UNALIGNED_ADDRESS = -7
     DIVISION_BY_ZERO = -8
-    BREAK = -127
+    BREAK = -126
+    OK_LONGJMP = -127
 
 
 @unique

--- a/src/specializer/gen-specializer
+++ b/src/specializer/gen-specializer
@@ -166,7 +166,7 @@ class Label:
         code = Code(
             '// History: {}'.format(' '.join(i.name for i in self.path)),
             '// Future: {}'.format(' '.join(i.name for i in self.preguess)),
-            'assert(error == MIT_ERROR_BREAK);',
+            'assert(error == MIT_ERROR_OK);',
             f'assert(cached_depth == {self.cached_depth()});',
             'if ({}) {{'.format(' && '.join(tests)),
             c_code,
@@ -228,7 +228,7 @@ def gen_labels_code(profiling=False):
         //
         // The calling convention at each A_XXX label is as follows:
         //
-        //  - On entry, `error` is `MIT_ERROR_BREAK`. `cached_depth` is a
+        //  - On entry, `error` is `MIT_ERROR_OK`. `cached_depth` is a
         //    compile-time constant indicating how many top stack items are in
         //    C variables.
         //  - Before running the `Instructions.code` for an instruction,
@@ -248,7 +248,7 @@ def gen_labels_code(profiling=False):
     code.append('')
     code.append('''\
         A_FALLBACK:
-            assert(error == MIT_ERROR_BREAK);
+            assert(error == MIT_ERROR_OK);
             assert(cached_depth == 0);
             uint8_t opcode = (uint8_t)ir;
             ir = ARSHIFT(ir, 8);
@@ -288,7 +288,7 @@ def gen_body_code(profiling=False):
     code = Code()
     code.append('''\
         mit_uword_t stack_words = mit_stack_words;
-        mit_word_t error = MIT_ERROR_BREAK;
+        mit_word_t error = MIT_ERROR_OK;
     ''')
     if max_cached_depth > 0:
         cache_state = CacheState(max_cached_depth, 0)

--- a/tests/branch.py
+++ b/tests/branch.py
@@ -171,7 +171,7 @@ def test_callback(handler, stack):
         sys.exit(1)
     done += 1
     if done == len(correct):
-        return MitErrorCode.OK
+        return MitErrorCode.BREAK
 trace(addr=0, step_callback=test_callback)
 
 print("Branch tests ran OK")

--- a/tests/mit_test.py
+++ b/tests/mit_test.py
@@ -34,6 +34,6 @@ def run_test(name, state, correct):
             sys.exit(1)
         done += 1
         if done == len(correct):
-            return MitErrorCode.OK
+            return MitErrorCode.BREAK
     state.step(trace=True, addr=0, step_callback=test_callback)
     print(f"{name.capitalize()} tests ran OK")


### PR DESCRIPTION
Therefore use MIT_ERROR_BREAK to mean “break function wants to halt
execution”.

Introduce a new error code MIT_ERROR_OK_LONGJMP to use for MIT_ERROR_OK in
longjmp, where code 0 cannot be used. (MIT_ERROR_BREAK was previously used
for this.)